### PR TITLE
Add Automata Wiki's DOT file support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,5 +48,8 @@ Style/CombinableLoops:
 Style/CommentedKeyword:
   Enabled: false
 
+Style/ConditionalAssignment:
+  Enabled: false
+
 Minitest/MultipleAssertions:
   Enabled: false

--- a/lib/lernen/automaton/dfa.rb
+++ b/lib/lernen/automaton/dfa.rb
@@ -199,6 +199,54 @@ module Lernen
 
         new(0, accept_state_set, transition_function)
       end
+
+      # Constructs DFA from [Automata Wiki](https://automata.cs.ru.nl)'s DOT source.
+      #
+      # It returns a tuple with two elements:
+      #
+      # 1. A `DAF` from the DOT source.
+      # 2. A `Hash` mapping from state IDs to names.
+      #
+      #: (String source) -> [DFA[String], Hash[Integer, String]]
+      def self.from_automata_wiki_dot(source)
+        name_to_state, initial_state, state_nodes, transitions = TransitionSystem.parse_automata_wiki_dot(source)
+
+        accept_state_set = Set.new
+        state_nodes.each do |state, _, shape|
+          next unless shape == "doublecircle"
+          accept_state_set << state
+        end
+
+        transition_function = {}
+        transitions.each { |from, to, label| transition_function[[from, label]] = to }
+
+        state_to_name = name_to_state.to_h { |name, state| [state, name] }
+
+        [new(initial_state, accept_state_set, transition_function), state_to_name]
+      end
+
+      # Returns [Automata Wiki](https://automata.cs.ru.nl)'s DOT representation of this DFA.
+      #
+      #: (?Hash[Integer, String] state_to_name) -> String
+      def to_automata_wiki_dot(state_to_name = {})
+        nodes = {}
+        nodes["__start0"] = Graph::Node["", :none]
+        states.each do |state|
+          name = state_to_name[state] || state
+          shape = accept_state_set.include?(state) ? :doublecircle : :circle #: Graph::node_shape
+          nodes[name] = Graph::Node[name.to_s, shape]
+        end
+
+        edges =
+          [Graph::Edge["__start0", nil, state_to_name[initial_state] || initial_state]] +
+            transition_function.map do |(state, input), next_state|
+              name = state_to_name[state] || state
+              next_name = state_to_name[next_state] || next_state
+              Graph::Edge[name, input.to_s, next_name] # steep:ignore
+            end
+
+        Graph.new(nodes, edges).to_dot
+      end
     end
   end
 end

--- a/lib/lernen/automaton/dfa.rb
+++ b/lib/lernen/automaton/dfa.rb
@@ -205,7 +205,7 @@ module Lernen
       #
       # It returns a tuple with two elements:
       #
-      # 1. A `DAF` from the DOT source.
+      # 1. A `DFA` from the DOT source.
       # 2. A `Hash` mapping from state IDs to names.
       #
       #: (String source) -> [DFA[String], Hash[Integer, String]]
@@ -230,8 +230,15 @@ module Lernen
       #
       #: (?Hash[Integer, String] state_to_name) -> String
       def to_automata_wiki_dot(state_to_name = {})
+        to_automata_wiki_dot_graph(state_to_name).to_dot
+      end
+
+      # Returns the `Graph` of [Automata Wiki](https://automata.cs.ru.nl)'s DOT representation of this DFA.
+      #
+      #: (?Hash[Integer, String] state_to_name, ?String initial_state_suffix) -> Graph
+      def to_automata_wiki_dot_graph(state_to_name = {}, initial_state_suffix = "")
         nodes = {}
-        nodes["__start0"] = Graph::Node["", :none]
+        nodes["__start0#{initial_state_suffix}"] = Graph::Node["", :none]
         states.each do |state|
           name = state_to_name[state] || state
           shape = accept_state_set.include?(state) ? :doublecircle : :circle #: Graph::node_shape
@@ -239,14 +246,14 @@ module Lernen
         end
 
         edges =
-          [Graph::Edge["__start0", nil, state_to_name[initial_state] || initial_state]] +
+          [Graph::Edge["__start0#{initial_state_suffix}", nil, state_to_name[initial_state] || initial_state]] +
             transition_function.map do |(state, input), next_state|
               name = state_to_name[state] || state
               next_name = state_to_name[next_state] || next_state
               Graph::Edge[name, input.to_s, next_name] # steep:ignore
             end
 
-        Graph.new(nodes, edges).to_dot
+        Graph.new(nodes, edges)
       end
     end
   end

--- a/lib/lernen/automaton/dfa.rb
+++ b/lib/lernen/automaton/dfa.rb
@@ -201,6 +201,7 @@ module Lernen
       end
 
       # Constructs DFA from [Automata Wiki](https://automata.cs.ru.nl)'s DOT source.
+      # See https://automata.cs.ru.nl/Syntax/Acceptor?from=Syntax.DFA.
       #
       # It returns a tuple with two elements:
       #

--- a/lib/lernen/automaton/dfa.rb
+++ b/lib/lernen/automaton/dfa.rb
@@ -200,7 +200,7 @@ module Lernen
         new(0, accept_state_set, transition_function)
       end
 
-      # Constructs DFA from [Automata Wiki](https://automata.cs.ru.nl)'s DOT source.
+      # Constructs a DFA from [Automata Wiki](https://automata.cs.ru.nl)'s DOT source.
       # See https://automata.cs.ru.nl/Syntax/Acceptor?from=Syntax.DFA.
       #
       # It returns a tuple with two elements:

--- a/lib/lernen/automaton/dfa.rb
+++ b/lib/lernen/automaton/dfa.rb
@@ -212,13 +212,13 @@ module Lernen
         name_to_state, initial_state, state_nodes, transitions = TransitionSystem.parse_automata_wiki_dot(source)
 
         accept_state_set = Set.new
-        state_nodes.each do |state, _, shape|
+        state_nodes.each do |(state, _, shape)|
           next unless shape == "doublecircle"
           accept_state_set << state
         end
 
         transition_function = {}
-        transitions.each { |from, to, label| transition_function[[from, label]] = to }
+        transitions.each { |(from, to, label)| transition_function[[from, label]] = to }
 
         state_to_name = name_to_state.to_h { |name, state| [state, name] }
 

--- a/lib/lernen/automaton/mealy.rb
+++ b/lib/lernen/automaton/mealy.rb
@@ -103,6 +103,54 @@ module Lernen
 
         new(0, transition_function)
       end
+
+      RE_MEALY_LABEL = %r{\A\s*(?<input_value>[^\s/]+)\s*/\s*(?<output_value>[^\s/]+)\s*\z}
+
+      # Constructs a Mealy machine from [Automata Wiki](https://automata.cs.ru.nl)'s DOT source.
+      # See https://automata.cs.ru.nl/Syntax/Mealy.
+      #
+      # It returns a tuple with two elements:
+      #
+      # 1. A `Mealy` from the DOT source.
+      # 2. A `Hash` mapping from state IDs to names.
+      #
+      #: (String source) -> [Mealy[String, String], Hash[Integer, String]]
+      def self.from_automata_wiki_dot(source)
+        name_to_state, initial_state, _, transitions = TransitionSystem.parse_automata_wiki_dot(source)
+
+        transition_function = {}
+        transitions.each do |(from, to, label)|
+          match = label.match(RE_MEALY_LABEL)
+          raise ArgumentError, "Invalid DOT" unless match
+          transition_function[[from, match[:input_value]]] = [match[:output_value], to]
+        end
+
+        state_to_name = name_to_state.to_h { |name, state| [state, name] }
+
+        [new(initial_state, transition_function), state_to_name]
+      end
+
+      # Returns [Automata Wiki](https://automata.cs.ru.nl)'s DOT representation of this Mealy machine.
+      #
+      #: (?Hash[Integer, String] state_to_name) -> String
+      def to_automata_wiki_dot(state_to_name = {})
+        nodes = {}
+        nodes["__start0"] = Graph::Node["", :none]
+        states.each do |state|
+          name = state_to_name[state] || state
+          nodes[name] = Graph::Node[name.to_s, :circle]
+        end
+
+        edges =
+          [Graph::Edge["__start0", nil, state_to_name[initial_state] || initial_state]] +
+            transition_function.map do |(state, input), (output, next_state)|
+              name = state_to_name[state] || state
+              next_name = state_to_name[next_state] || next_state
+              Graph::Edge[name, "#{input} / #{output}", next_name] # steep:ignore
+            end
+
+        Graph.new(nodes, edges).to_dot
+      end
     end
   end
 end

--- a/lib/lernen/automaton/mealy.rb
+++ b/lib/lernen/automaton/mealy.rb
@@ -104,7 +104,7 @@ module Lernen
         new(0, transition_function)
       end
 
-      RE_MEALY_LABEL = %r{\A\s*(?<input_value>[^\s/]+)\s*/\s*(?<output_value>[^\s/]+)\s*\z}
+      RE_MEALY_LABEL = %r{\A\s*(?<input_value>[^\s/]+)\s*/\s*(?<output_value>[^\s]+)\s*\z}
 
       # Constructs a Mealy machine from [Automata Wiki](https://automata.cs.ru.nl)'s DOT source.
       # See https://automata.cs.ru.nl/Syntax/Mealy.

--- a/lib/lernen/automaton/moore.rb
+++ b/lib/lernen/automaton/moore.rb
@@ -118,7 +118,7 @@ module Lernen
         new(0, output_function, transition_function)
       end
 
-      RE_MOORE_LABEL = /\A\{\s*(?<state_name>[^\s|]+)\s*\|\s*(?<output_value>[^\s|]+)\s*\}\z/
+      RE_MOORE_LABEL = /\A\{\s*(?<state_name>[^\s|]+)\s*\|\s*(?<output_value>[^\s]+)\s*\}\z/
 
       # Constructs a Moore machine from [Automata Wiki](https://automata.cs.ru.nl)'s DOT source.
       # See https://automata.cs.ru.nl/Syntax/Moore.

--- a/lib/lernen/automaton/moore.rb
+++ b/lib/lernen/automaton/moore.rb
@@ -69,7 +69,7 @@ module Lernen
       def to_graph
         nodes =
           states.to_h do |state|
-            [state, Graph::Node["#{state} | #{output_function[state].inspect}", :circle]] # steep:ignore
+            [state, Graph::Node["#{state} | #{output_function[state].inspect}", :record]] # steep:ignore
           end
 
         edges =
@@ -116,6 +116,57 @@ module Lernen
         end
 
         new(0, output_function, transition_function)
+      end
+
+      RE_MOORE_LABEL = /\A\{\s*(?<state_name>\w+)\s*\|\s*(?<output_value>\w+)\s*\}\z/
+
+      # Constructs a Moore machine from [Automata Wiki](https://automata.cs.ru.nl)'s DOT source.
+      #
+      # It returns a tuple with two elements:
+      #
+      # 1. A `Moore` from the DOT source.
+      # 2. A `Hash` mapping from state IDs to names.
+      #
+      #: (String source) -> [Moore[String, String], Hash[Integer, String]]
+      def self.from_automata_wiki_dot(source)
+        name_to_state, initial_state, state_nodes, transitions = TransitionSystem.parse_automata_wiki_dot(source)
+
+        output_function = {}
+        state_nodes.each do |(state, label, _)|
+          match = label.match(RE_MOORE_LABEL)
+          raise ArgumentError, "Invalid DOT" unless match
+          output_function[state] = match[:output_value]
+        end
+
+        transition_function = {}
+        transitions.each { |(from, to, label)| transition_function[[from, label]] = to }
+
+        state_to_name = name_to_state.to_h { |name, state| [state, name] }
+
+        [new(initial_state, output_function, transition_function), state_to_name]
+      end
+
+      # Returns [Automata Wiki](https://automata.cs.ru.nl)'s DOT representation of this Moore machine.
+      #
+      #: (?Hash[Integer, String] state_to_name) -> String
+      def to_automata_wiki_dot(state_to_name = {})
+        nodes = {}
+        nodes["__start0"] = Graph::Node["", :none]
+        states.each do |state|
+          name = state_to_name[state] || state
+
+          nodes[name] = Graph::Node["#{name} | #{output_function[state]}", :record]
+        end
+
+        edges =
+          [Graph::Edge["__start0", nil, state_to_name[initial_state] || initial_state]] +
+            transition_function.map do |(state, input), next_state|
+              name = state_to_name[state] || state
+              next_name = state_to_name[next_state] || next_state
+              Graph::Edge[name, input.to_s, next_name] # steep:ignore
+            end
+
+        Graph.new(nodes, edges).to_dot
       end
     end
   end

--- a/lib/lernen/automaton/moore.rb
+++ b/lib/lernen/automaton/moore.rb
@@ -118,9 +118,10 @@ module Lernen
         new(0, output_function, transition_function)
       end
 
-      RE_MOORE_LABEL = /\A\{\s*(?<state_name>\w+)\s*\|\s*(?<output_value>\w+)\s*\}\z/
+      RE_MOORE_LABEL = /\A\{\s*(?<state_name>[^\s|]+)\s*\|\s*(?<output_value>[^\s|]+)\s*\}\z/
 
       # Constructs a Moore machine from [Automata Wiki](https://automata.cs.ru.nl)'s DOT source.
+      # See https://automata.cs.ru.nl/Syntax/Moore.
       #
       # It returns a tuple with two elements:
       #
@@ -154,7 +155,6 @@ module Lernen
         nodes["__start0"] = Graph::Node["", :none]
         states.each do |state|
           name = state_to_name[state] || state
-
           nodes[name] = Graph::Node["#{name} | #{output_function[state]}", :record]
         end
 

--- a/lib/lernen/automaton/transition_system.rb
+++ b/lib/lernen/automaton/transition_system.rb
@@ -206,7 +206,7 @@ module Lernen
       end
 
       RE_COMMENT = %r{/\*(?:(?!\*/).)*\*/|//.*|\A\s*#.*}
-      RE_INITIAL_STATE = /\b__start0\s*->\s*(?<initial_state_name>\w+)/
+      RE_INITIAL_STATE = /\b__start0(?:_\w+)?\s*->\s*(?<initial_state_name>\w+)/
       RE_TRANSITION = /\b(?<from_name>\w+)\s*->\s*(?<to_name>\w+)\s*\[(?<params>(?:"[^"]*"|[^\]]+)*)\]/
       RE_STATE = /\b(?<name>\w+)\s*\[(?<params>(?:"[^"]*"|[^\]]+)*)\]/
       RE_LABEL = /\blabel=(?<content>"[^"]*"|[^\s\],]*)/

--- a/lib/lernen/automaton/transition_system.rb
+++ b/lib/lernen/automaton/transition_system.rb
@@ -204,6 +204,87 @@ module Lernen
 
         [transition_function, reachable_paths]
       end
+
+      RE_COMMENT = %r{/\*(?:(?!\*/).)*\*/|//.*|\A\s*#.*}
+      RE_INITIAL_STATE = /\b__start0\s*->\s*(?<initial_state_name>\w+)/
+      RE_TRANSITION = /\b(?<from_name>\w+)\s*->\s*(?<to_name>\w+)\s*\[(?<params>(?:"[^"]*"|[^\]]+)*)\]/
+      RE_STATE = /\b(?<name>\w+)\s*\[(?<params>(?:"[^"]*"|[^\]]+)*)\]/
+      RE_LABEL = /\blabel=(?<content>"[^"]*"|[^\s\],]*)/
+      RE_SHAPE = /\bshape=(?<content>"[^"]*"|[^\s\],]*)/
+
+      # Parses the given [Automata Wiki](https://automata.cs.ru.nl)'s DOT source.
+      # See <https://automata.cs.ru.nl/Syntax/Overview>.
+      #
+      # It returns a tuple with four elements:
+      #
+      # 1. A `Hash` mapping from state names to state IDs.
+      # 2. An initial state ID.
+      # 3. An `Array` of state node information `[state, label, shape]`.
+      # 4. An `Array` of transition information `[from_state, to_state, label]`.
+      #
+      # Note that the implementation of this function is very cheap and does not parse the DOT format accurately.
+      #
+      #: (String source) -> [
+      #    Hash[String, Integer],
+      #    Integer,
+      #    Array[[Integer, String, String]],
+      #    Array[[Integer, Integer, String]]
+      #  ]
+      def self.parse_automata_wiki_dot(source)
+        initial_state = 0
+        name_to_state = {}
+        state_nodes = []
+        transitions = []
+
+        strip = ->(label) { label[0] == "\"" && label[-1] == "\"" ? label[1...-1] : label }
+
+        source.lines do |line|
+          line = line.gsub(RE_COMMENT, "")
+
+          match = line.match(RE_INITIAL_STATE)
+          if match
+            initial_state_name = match[:initial_state_name]
+            name_to_state[initial_state_name] ||= name_to_state.size
+            initial_state = name_to_state[initial_state_name]
+            next
+          end
+
+          match = line.match(RE_TRANSITION)
+          if match
+            from_name = match[:from_name]
+            name_to_state[from_name] ||= name_to_state.size
+            from = name_to_state[from_name]
+
+            to_name = match[:to_name]
+            name_to_state[to_name] ||= name_to_state.size
+            to = name_to_state[to_name]
+
+            params = match[:params] || ""
+            label = strip.call(params.match(RE_LABEL)&.[](:content) || "")
+
+            transitions << [from, to, label]
+            next
+          end
+
+          match = line.match(RE_STATE)
+          if match
+            name = match[:name]
+            next if name == "__start0"
+
+            name_to_state[name] ||= name_to_state.size
+            state = name_to_state[name]
+
+            params = match[:params] || ""
+            label = strip.call(params.match(RE_LABEL)&.[](:content) || "")
+            shape = strip.call(params.match(RE_SHAPE)&.[](:content) || "")
+
+            state_nodes << [state, label, shape]
+            next
+          end
+        end
+
+        [name_to_state, initial_state, state_nodes, transitions]
+      end
     end
   end
 end

--- a/lib/lernen/graph.rb
+++ b/lib/lernen/graph.rb
@@ -7,7 +7,7 @@ module Lernen
   # This is an intermediate data structure for rendering Mermaid and Graphviz diagrams.
   class Graph
     # @rbs!
-    #   type node_shape = :circle | :doublecircle | :none
+    #   type node_shape = :circle | :doublecircle | :record | :none
     #
     #   type mermaid_direction = "TD" | "DT" | "LR" | "RL"
 
@@ -144,6 +144,8 @@ module Lernen
             "((#{Graph.mermaid_escape(node.label)}))"
           in :doublecircle
             "(((#{Graph.mermaid_escape(node.label)})))"
+          in :record
+            "(#{Graph.mermaid_escape(node.label)})"
           in :none
             "@{ shape: sm-circ }"
           end
@@ -188,7 +190,12 @@ module Lernen
       nodes.each do |index, node|
         needs_sep = true
 
-        dot << "  #{id_prefix}#{index} [label=#{Graph.dot_escape(node.label)}, shape=#{node.shape}];\n"
+        if node.shape == :record
+          label = Graph.dot_escape("{ #{node.label} }")
+          dot << "  #{id_prefix}#{index} [label=#{label}, shape=record, style=rounded];\n"
+        else
+          dot << "  #{id_prefix}#{index} [label=#{Graph.dot_escape(node.label)}, shape=#{node.shape}];\n"
+        end
       end
       dot << "\n" if needs_sep
 

--- a/lib/lernen/graph.rb
+++ b/lib/lernen/graph.rb
@@ -7,7 +7,7 @@ module Lernen
   # This is an intermediate data structure for rendering Mermaid and Graphviz diagrams.
   class Graph
     # @rbs!
-    #   type node_shape = :circle | :doublecircle
+    #   type node_shape = :circle | :doublecircle | :none
     #
     #   type mermaid_direction = "TD" | "DT" | "LR" | "RL"
 
@@ -30,10 +30,10 @@ module Lernen
 
     # @rbs!
     #   class Edge < Data
-    #     attr_reader from: Integer
-    #     attr_reader label: String
-    #     attr_reader to: Integer
-    #     def self.[]: (Integer from, String label, Integer to) -> Edge
+    #     attr_reader from: Integer | String
+    #     attr_reader label: String | nil
+    #     attr_reader to: Integer | String
+    #     def self.[]: (Integer | String from, String | nil label, Integer | String to) -> Edge
     #   end
 
     # SubGraph represents a sub-graph of graphs.
@@ -84,12 +84,12 @@ module Lernen
       "\"#{label}\""
     end
 
-    # @rbs @nodes: Hash[Integer, Node]
+    # @rbs @nodes: Hash[Integer | String, Node]
     # @rbs @edges: Array[Edge]
     # @rbs @subgraphs: Array[SubGraph]
 
     #: (
-    #    Hash[Integer, Node] nodes,
+    #    Hash[Integer | String, Node] nodes,
     #    Array[Edge] edges,
     #    ?Array[SubGraph] subgraphs
     #  ) -> void
@@ -99,7 +99,7 @@ module Lernen
       @subgraphs = subgraphs
     end
 
-    attr_reader :nodes #: Hash[Integer, Node]
+    attr_reader :nodes #: Hash[Integer | String, Node]
     attr_reader :edges #: Array[Edge]
     attr_reader :subgraphs #: Array[SubGraph]
 
@@ -144,6 +144,8 @@ module Lernen
             "((#{Graph.mermaid_escape(node.label)}))"
           in :doublecircle
             "(((#{Graph.mermaid_escape(node.label)})))"
+          in :none
+            "@{ shape: sm-circ }"
           end
         mmd << "  #{id_prefix}#{id}#{node_def}\n"
       end
@@ -154,7 +156,11 @@ module Lernen
 
         from = "#{id_prefix}#{edge.from}"
         to = "#{id_prefix}#{edge.to}"
-        mmd << "  #{from} -- #{Graph.mermaid_escape(edge.label)} --> #{to}\n"
+        if edge.label
+          mmd << "  #{from} -- #{Graph.mermaid_escape(edge.label)} --> #{to}\n"
+        else
+          mmd << "  #{from} --> #{to}\n"
+        end
       end
 
       subgraphs.each_with_index do |subgraph, index|
@@ -191,7 +197,11 @@ module Lernen
 
         from = "#{id_prefix}#{edge.from}"
         to = "#{id_prefix}#{edge.to}"
-        dot << "  #{from} -> #{to} [label=#{Graph.dot_escape(edge.label)}];\n"
+        if edge.label
+          dot << "  #{from} -> #{to} [label=#{Graph.dot_escape(edge.label)}];\n"
+        else
+          dot << "  #{from} -> #{to};\n"
+        end
       end
 
       subgraphs.each_with_index do |subgraph, index|

--- a/lib/lernen/graph.rb
+++ b/lib/lernen/graph.rb
@@ -189,12 +189,13 @@ module Lernen
 
       nodes.each do |index, node|
         needs_sep = true
+        name = index.is_a?(String) ? index : "#{id_prefix}#{index}"
 
         if node.shape == :record
           label = Graph.dot_escape("{ #{node.label} }")
-          dot << "  #{id_prefix}#{index} [label=#{label}, shape=record, style=rounded];\n"
+          dot << "  #{name} [label=#{label}, shape=record, style=rounded];\n"
         else
-          dot << "  #{id_prefix}#{index} [label=#{Graph.dot_escape(node.label)}, shape=#{node.shape}];\n"
+          dot << "  #{name} [label=#{Graph.dot_escape(node.label)}, shape=#{node.shape}];\n"
         end
       end
       dot << "\n" if needs_sep
@@ -202,8 +203,8 @@ module Lernen
       edges.each do |edge|
         needs_sep = true
 
-        from = "#{id_prefix}#{edge.from}"
-        to = "#{id_prefix}#{edge.to}"
+        from = edge.from.is_a?(String) ? edge.from : "#{id_prefix}#{edge.from}"
+        to = edge.to.is_a?(String) ? edge.to : "#{id_prefix}#{edge.to}"
         if edge.label
           dot << "  #{from} -> #{to} [label=#{Graph.dot_escape(edge.label)}];\n"
         else

--- a/sig-test/generated/test/lernen/automaton/dfa_test.rbs
+++ b/sig-test/generated/test/lernen/automaton/dfa_test.rbs
@@ -14,6 +14,9 @@ module Lernen
 
       # : () -> void
       def test_to_dot: () -> void
+
+      # : () -> void
+      def test_from_and_to_automata_wiki_dot: () -> void
     end
   end
 end

--- a/sig-test/generated/test/lernen/automaton/mealy_test.rbs
+++ b/sig-test/generated/test/lernen/automaton/mealy_test.rbs
@@ -14,6 +14,9 @@ module Lernen
 
       # : () -> void
       def test_to_dot: () -> void
+
+      # : () -> void
+      def test_from_and_to_automata_wiki_dot: () -> void
     end
   end
 end

--- a/sig-test/generated/test/lernen/automaton/moore_test.rbs
+++ b/sig-test/generated/test/lernen/automaton/moore_test.rbs
@@ -14,6 +14,9 @@ module Lernen
 
       # : () -> void
       def test_to_dot: () -> void
+
+      # : () -> void
+      def test_from_and_to_automata_wiki_dot: () -> void
     end
   end
 end

--- a/sig-test/generated/test/lernen/automaton/spa_test.rbs
+++ b/sig-test/generated/test/lernen/automaton/spa_test.rbs
@@ -14,6 +14,9 @@ module Lernen
 
       # : () -> void
       def test_to_dot: () -> void
+
+      # : () -> void
+      def test_from_and_to_automata_wiki_dot: () -> void
     end
   end
 end

--- a/sig-test/generated/test/lernen/automaton/vpa_test.rbs
+++ b/sig-test/generated/test/lernen/automaton/vpa_test.rbs
@@ -14,6 +14,9 @@ module Lernen
 
       # : () -> void
       def test_to_dot: () -> void
+
+      # : () -> void
+      def test_from_and_to_automata_wiki_dot: () -> void
     end
   end
 end

--- a/sig/generated/lernen/automaton/dfa.rbs
+++ b/sig/generated/lernen/automaton/dfa.rbs
@@ -89,7 +89,7 @@ module Lernen
       #  ) -> DFA[In]
       def self.random: [In] (alphabet: Array[In], ?min_state_size: Integer, ?max_state_size: Integer, ?accept_state_size: Integer, ?random: Random) -> DFA[In]
 
-      # Constructs DFA from [Automata Wiki](https://automata.cs.ru.nl)'s DOT source.
+      # Constructs a DFA from [Automata Wiki](https://automata.cs.ru.nl)'s DOT source.
       # See https://automata.cs.ru.nl/Syntax/Acceptor?from=Syntax.DFA.
       #
       # It returns a tuple with two elements:

--- a/sig/generated/lernen/automaton/dfa.rbs
+++ b/sig/generated/lernen/automaton/dfa.rbs
@@ -94,7 +94,7 @@ module Lernen
       #
       # It returns a tuple with two elements:
       #
-      # 1. A `DAF` from the DOT source.
+      # 1. A `DFA` from the DOT source.
       # 2. A `Hash` mapping from state IDs to names.
       #
       # : (String source) -> [DFA[String], Hash[Integer, String]]
@@ -104,6 +104,11 @@ module Lernen
       #
       # : (?Hash[Integer, String] state_to_name) -> String
       def to_automata_wiki_dot: (?Hash[Integer, String] state_to_name) -> String
+
+      # Returns the `Graph` of [Automata Wiki](https://automata.cs.ru.nl)'s DOT representation of this DFA.
+      #
+      # : (?Hash[Integer, String] state_to_name, ?String initial_state_suffix) -> Graph
+      def to_automata_wiki_dot_graph: (?Hash[Integer, String] state_to_name, ?String initial_state_suffix) -> Graph
     end
   end
 end

--- a/sig/generated/lernen/automaton/dfa.rbs
+++ b/sig/generated/lernen/automaton/dfa.rbs
@@ -90,6 +90,7 @@ module Lernen
       def self.random: [In] (alphabet: Array[In], ?min_state_size: Integer, ?max_state_size: Integer, ?accept_state_size: Integer, ?random: Random) -> DFA[In]
 
       # Constructs DFA from [Automata Wiki](https://automata.cs.ru.nl)'s DOT source.
+      # See https://automata.cs.ru.nl/Syntax/Acceptor?from=Syntax.DFA.
       #
       # It returns a tuple with two elements:
       #

--- a/sig/generated/lernen/automaton/dfa.rbs
+++ b/sig/generated/lernen/automaton/dfa.rbs
@@ -88,6 +88,21 @@ module Lernen
       #    ?random: Random,
       #  ) -> DFA[In]
       def self.random: [In] (alphabet: Array[In], ?min_state_size: Integer, ?max_state_size: Integer, ?accept_state_size: Integer, ?random: Random) -> DFA[In]
+
+      # Constructs DFA from [Automata Wiki](https://automata.cs.ru.nl)'s DOT source.
+      #
+      # It returns a tuple with two elements:
+      #
+      # 1. A `DAF` from the DOT source.
+      # 2. A `Hash` mapping from state IDs to names.
+      #
+      # : (String source) -> [DFA[String], Hash[Integer, String]]
+      def self.from_automata_wiki_dot: (String source) -> [ DFA[String], Hash[Integer, String] ]
+
+      # Returns [Automata Wiki](https://automata.cs.ru.nl)'s DOT representation of this DFA.
+      #
+      # : (?Hash[Integer, String] state_to_name) -> String
+      def to_automata_wiki_dot: (?Hash[Integer, String] state_to_name) -> String
     end
   end
 end

--- a/sig/generated/lernen/automaton/mealy.rbs
+++ b/sig/generated/lernen/automaton/mealy.rbs
@@ -7,9 +7,9 @@ module Lernen
     # @rbs generic In  -- Type for input alphabet
     # @rbs generic Out -- Type for output values
     class Mealy[In, Out] < TransitionSystem[Integer, In, Out]
-      @initial_state: Integer
-
       @transition_function: Hash[[ Integer, In ], [ Out, Integer ]]
+
+      @initial_state: Integer
 
       # : (
       #     Integer initial_state,
@@ -56,6 +56,24 @@ module Lernen
       #    ?random: Random,
       #  ) -> Mealy[In, Out]
       def self.random: [In, Out] (alphabet: Array[In], output_alphabet: Array[Out], ?min_state_size: Integer, ?max_state_size: Integer, ?num_reachable_paths: Integer, ?random: Random) -> Mealy[In, Out]
+
+      RE_MEALY_LABEL: ::Regexp
+
+      # Constructs a Mealy machine from [Automata Wiki](https://automata.cs.ru.nl)'s DOT source.
+      # See https://automata.cs.ru.nl/Syntax/Mealy.
+      #
+      # It returns a tuple with two elements:
+      #
+      # 1. A `Mealy` from the DOT source.
+      # 2. A `Hash` mapping from state IDs to names.
+      #
+      # : (String source) -> [Mealy[String, String], Hash[Integer, String]]
+      def self.from_automata_wiki_dot: (String source) -> [ Mealy[String, String], Hash[Integer, String] ]
+
+      # Returns [Automata Wiki](https://automata.cs.ru.nl)'s DOT representation of this Mealy machine.
+      #
+      # : (?Hash[Integer, String] state_to_name) -> String
+      def to_automata_wiki_dot: (?Hash[Integer, String] state_to_name) -> String
     end
   end
 end

--- a/sig/generated/lernen/automaton/moore.rbs
+++ b/sig/generated/lernen/automaton/moore.rbs
@@ -64,6 +64,23 @@ module Lernen
       #    ?random: Random,
       #  ) -> Moore[In, Out]
       def self.random: [In, Out] (alphabet: Array[In], output_alphabet: Array[Out], ?min_state_size: Integer, ?max_state_size: Integer, ?num_reachable_paths: Integer, ?random: Random) -> Moore[In, Out]
+
+      RE_MOORE_LABEL: ::Regexp
+
+      # Constructs a Moore machine from [Automata Wiki](https://automata.cs.ru.nl)'s DOT source.
+      #
+      # It returns a tuple with two elements:
+      #
+      # 1. A `Moore` from the DOT source.
+      # 2. A `Hash` mapping from state IDs to names.
+      #
+      # : (String source) -> [Moore[String, String], Hash[Integer, String]]
+      def self.from_automata_wiki_dot: (String source) -> [ Moore[String, String], Hash[Integer, String] ]
+
+      # Returns [Automata Wiki](https://automata.cs.ru.nl)'s DOT representation of this Moore machine.
+      #
+      # : (?Hash[Integer, String] state_to_name) -> String
+      def to_automata_wiki_dot: (?Hash[Integer, String] state_to_name) -> String
     end
   end
 end

--- a/sig/generated/lernen/automaton/moore.rbs
+++ b/sig/generated/lernen/automaton/moore.rbs
@@ -68,6 +68,7 @@ module Lernen
       RE_MOORE_LABEL: ::Regexp
 
       # Constructs a Moore machine from [Automata Wiki](https://automata.cs.ru.nl)'s DOT source.
+      # See https://automata.cs.ru.nl/Syntax/Moore.
       #
       # It returns a tuple with two elements:
       #

--- a/sig/generated/lernen/automaton/spa.rbs
+++ b/sig/generated/lernen/automaton/spa.rbs
@@ -97,6 +97,31 @@ module Lernen
       #  ) -> SPA[In, Call, Return]
       def self.random: [In, Call, Return] (alphabet: Array[In], call_alphabet: Array[Call], return_input: Return, ?min_proc_size: Integer, ?max_proc_size: Integer, ?dfa_min_state_size: Integer, ?dfa_max_state_size: Integer, ?dfa_accept_state_size: Integer, ?random: Random) -> SPA[In, Call, Return]
 
+      RE_INITIAL_PROC: ::Regexp
+
+      RE_RETURN_INPUT: ::Regexp
+
+      RE_SUBGRAPH_BEGIN: ::Regexp
+
+      RE_SUBGRAPH_LABEL: ::Regexp
+
+      RE_SUBGRAPH_END: ::Regexp
+
+      # Constructs an SPA from [Automata Wiki](https://automata.cs.ru.nl)'s DOT source.
+      #
+      # It returns a tuple with two elements:
+      #
+      # 1. A `SPA` from the DOT source.
+      # 2. A `Hash` mapping from procedure names to state-to-name mappings.
+      #
+      # : (String source) -> [SPA[String, Symbol, Symbol], Hash[Symbol, Hash[Integer, String]]]
+      def self.from_automata_wiki_dot: (String source) -> [ SPA[String, Symbol, Symbol], Hash[Symbol, Hash[Integer, String]] ]
+
+      # Returns [Automata Wiki](https://automata.cs.ru.nl)'s DOT representation of this DFA.
+      #
+      # : (?Hash[Call, Hash[Integer, String]] proc_to_state_to_name) -> String
+      def to_automata_wiki_dot: (?Hash[Call, Hash[Integer, String]] proc_to_state_to_name) -> String
+
       private
 
       # Returns the mapping from procedure names to terminating sequences.

--- a/sig/generated/lernen/automaton/transition_system.rbs
+++ b/sig/generated/lernen/automaton/transition_system.rbs
@@ -103,6 +103,38 @@ module Lernen
       #    ?random: Random,
       #  ) -> [Hash[[Integer, In], Integer], Array[Array[Integer]]]
       def self.random_transition_function: [In] (alphabet: Array[In], ?min_state_size: Integer, ?max_state_size: Integer, ?num_reachable_paths: Integer, ?random: Random) -> [ Hash[[ Integer, In ], Integer], Array[Array[Integer]] ]
+
+      RE_COMMENT: ::Regexp
+
+      RE_INITIAL_STATE: ::Regexp
+
+      RE_TRANSITION: ::Regexp
+
+      RE_STATE: ::Regexp
+
+      RE_LABEL: ::Regexp
+
+      RE_SHAPE: ::Regexp
+
+      # Parses the given [Automata Wiki](https://automata.cs.ru.nl)'s DOT source.
+      # See <https://automata.cs.ru.nl/Syntax/Overview>.
+      #
+      # It returns a tuple with four elements:
+      #
+      # 1. A `Hash` mapping from state names to state IDs.
+      # 2. An initial state ID.
+      # 3. An `Array` of state node information `[state, label, shape]`.
+      # 4. An `Array` of transition information `[from_state, to_state, label]`.
+      #
+      # Note that the implementation of this function is very cheap and does not parse the DOT format accurately.
+      #
+      # : (String source) -> [
+      #    Hash[String, Integer],
+      #    Integer,
+      #    Array[[Integer, String, String]],
+      #    Array[[Integer, Integer, String]]
+      #  ]
+      def self.parse_automata_wiki_dot: (String source) -> [ Hash[String, Integer], Integer, Array[[ Integer, String, String ]], Array[[ Integer, Integer, String ]] ]
     end
   end
 end

--- a/sig/generated/lernen/automaton/vpa.rbs
+++ b/sig/generated/lernen/automaton/vpa.rbs
@@ -104,6 +104,23 @@ module Lernen
       #    ?random: Random,
       #  ) -> VPA[In, Call, Return]
       def self.random: [In, Call, Return] (alphabet: Array[In], call_alphabet: Array[Call], return_alphabet: Array[Return], ?min_state_size: Integer, ?max_state_size: Integer, ?accept_state_size: Integer, ?random: Random) -> VPA[In, Call, Return]
+
+      RE_VPA_LABEL: ::Regexp
+
+      # Constructs a VPA from [Automata Wiki](https://automata.cs.ru.nl)'s DOT source.
+      #
+      # It returns a tuple with two elements:
+      #
+      # 1. A `VPA` from the DOT source.
+      # 2. A `Hash` mapping from state IDs to names.
+      #
+      # : (String source) -> [VPA[String, String, String], Hash[Integer, String]]
+      def self.from_automata_wiki_dot: (String source) -> [ VPA[String, String, String], Hash[Integer, String] ]
+
+      # Returns [Automata Wiki](https://automata.cs.ru.nl)'s DOT representation of this VPA.
+      #
+      # : (?Hash[Integer, String] state_to_name) -> String
+      def to_automata_wiki_dot: (?Hash[Integer, String] state_to_name) -> String
     end
   end
 end

--- a/sig/generated/lernen/graph.rbs
+++ b/sig/generated/lernen/graph.rbs
@@ -5,7 +5,7 @@ module Lernen
   #
   # This is an intermediate data structure for rendering Mermaid and Graphviz diagrams.
   class Graph
-    type node_shape = :circle | :doublecircle
+    type node_shape = :circle | :doublecircle | :none
 
     type mermaid_direction = "TD" | "DT" | "LR" | "RL"
 
@@ -16,10 +16,10 @@ module Lernen
     end
 
     class Edge < Data
-      attr_reader from: Integer
-      attr_reader label: String
-      attr_reader to: Integer
-      def self.[]: (Integer from, String label, Integer to) -> Edge
+      attr_reader from: Integer | String
+      attr_reader label: String | nil
+      attr_reader to: Integer | String
+      def self.[]: (Integer | String from, String | nil label, Integer | String to) -> Edge
     end
 
     class SubGraph < Data
@@ -46,16 +46,16 @@ module Lernen
 
     @edges: Array[Edge]
 
-    @nodes: Hash[Integer, Node]
+    @nodes: Hash[Integer | String, Node]
 
     # : (
-    #     Hash[Integer, Node] nodes,
+    #     Hash[Integer | String, Node] nodes,
     #     Array[Edge] edges,
     #     ?Array[SubGraph] subgraphs
     #   ) -> void
-    def initialize: (Hash[Integer, Node] nodes, Array[Edge] edges, ?Array[SubGraph] subgraphs) -> void
+    def initialize: (Hash[Integer | String, Node] nodes, Array[Edge] edges, ?Array[SubGraph] subgraphs) -> void
 
-    attr_reader nodes: Hash[Integer, Node]
+    attr_reader nodes: Hash[Integer | String, Node]
 
     attr_reader edges: Array[Edge]
 

--- a/sig/generated/lernen/graph.rbs
+++ b/sig/generated/lernen/graph.rbs
@@ -5,7 +5,7 @@ module Lernen
   #
   # This is an intermediate data structure for rendering Mermaid and Graphviz diagrams.
   class Graph
-    type node_shape = :circle | :doublecircle | :none
+    type node_shape = :circle | :doublecircle | :record | :none
 
     type mermaid_direction = "TD" | "DT" | "LR" | "RL"
 

--- a/test/lernen/automaton/dfa_test.rb
+++ b/test/lernen/automaton/dfa_test.rb
@@ -83,6 +83,38 @@ module Lernen
         assert_equal expected, dfa.to_dot
         assert_predicate dfa.to_dot, :frozen?
       end
+
+      #: () -> void
+      def test_from_and_to_automata_wiki_dot
+        # From https://automata.cs.ru.nl/Syntax/Acceptor?from=Syntax.DFA.
+        dfa, state_to_name = DFA.from_automata_wiki_dot(<<~DOT)
+          digraph g {
+            __start0 [label="" shape="none"]
+            s1 [shape="doublecircle" label="s1"]
+            s2 [shape="circle" label="s2"]
+            __start0 -> s1
+            s1 -> s2[label="0"]
+            s1 -> s1[label="1"]
+            s2 -> s1[label="0"]
+            s2 -> s2[label="1"]
+          }
+        DOT
+        source = dfa.to_automata_wiki_dot(state_to_name)
+
+        assert_equal <<~DOT, source
+          digraph {
+            __start0 [label="", shape=none];
+            s1 [label="s1", shape=doublecircle];
+            s2 [label="s2", shape=circle];
+
+            __start0 -> s1;
+            s1 -> s2 [label="0"];
+            s1 -> s1 [label="1"];
+            s2 -> s1 [label="0"];
+            s2 -> s2 [label="1"];
+          }
+        DOT
+      end
     end
   end
 end

--- a/test/lernen/automaton/mealy_test.rb
+++ b/test/lernen/automaton/mealy_test.rb
@@ -82,6 +82,88 @@ module Lernen
         assert_equal expected, mealy.to_dot
         assert_predicate mealy.to_dot, :frozen?
       end
+
+      #: () -> void
+      def test_from_and_to_automata_wiki_dot
+        # From https://automata.cs.ru.nl/Syntax/Moore.
+        mealy, state_to_name = Mealy.from_automata_wiki_dot(<<~DOT)
+          digraph g {
+            __start0 [label="" shape="none"];
+            __start0 -> s0;
+
+            s0 [shape="circle" label="s0"];
+            s1 [shape="circle" label="s1"];
+            s2 [shape="circle" label="s2"];
+            s3 [shape="circle" label="s3"];
+            s4 [shape="circle" label="s4"];
+            s5 [shape="circle" label="s5"];
+
+            s0 -> s4 [label="WATER / ok"];
+            s0 -> s2 [label="POD / ok"];
+            s0 -> s1 [label="BUTTON / error"];
+            s0 -> s0 [label="CLEAN / ok"];
+            s1 -> s1 [label="WATER / error"];
+            s1 -> s1 [label="POD / error"];
+            s1 -> s1 [label="BUTTON / error"];
+            s1 -> s1 [label="CLEAN / error"];
+            s2 -> s3 [label="WATER / ok"];
+            s2 -> s2 [label="POD / ok"];
+            s2 -> s1 [label="BUTTON / error"];
+            s2 -> s0 [label="CLEAN / ok"];
+            s3 -> s3 [label="WATER / ok"];
+            s3 -> s3 [label="POD / ok"];
+            s3 -> s5 [label="BUTTON / coffee!"];
+            s3 -> s0 [label="CLEAN / ok"];
+            s4 -> s4 [label="WATER / ok"];
+            s4 -> s3 [label="POD / ok"];
+            s4 -> s1 [label="BUTTON / error"];
+            s4 -> s0 [label="CLEAN / ok"];
+            s5 -> s1 [label="WATER / error"];
+            s5 -> s1 [label="POD / error"];
+            s5 -> s1 [label="BUTTON / error"];
+            s5 -> s0 [label="CLEAN / ok"];
+          }
+        DOT
+        source = mealy.to_automata_wiki_dot(state_to_name)
+
+        assert_equal <<~DOT, source
+          digraph {
+            __start0 [label="", shape=none];
+            s0 [label="s0", shape=circle];
+            s1 [label="s1", shape=circle];
+            s2 [label="s2", shape=circle];
+            s3 [label="s3", shape=circle];
+            s4 [label="s4", shape=circle];
+            s5 [label="s5", shape=circle];
+
+            __start0 -> s0;
+            s0 -> s4 [label="WATER / ok"];
+            s0 -> s2 [label="POD / ok"];
+            s0 -> s1 [label="BUTTON / error"];
+            s0 -> s0 [label="CLEAN / ok"];
+            s1 -> s1 [label="WATER / error"];
+            s1 -> s1 [label="POD / error"];
+            s1 -> s1 [label="BUTTON / error"];
+            s1 -> s1 [label="CLEAN / error"];
+            s2 -> s3 [label="WATER / ok"];
+            s2 -> s2 [label="POD / ok"];
+            s2 -> s1 [label="BUTTON / error"];
+            s2 -> s0 [label="CLEAN / ok"];
+            s3 -> s3 [label="WATER / ok"];
+            s3 -> s3 [label="POD / ok"];
+            s3 -> s5 [label="BUTTON / coffee!"];
+            s3 -> s0 [label="CLEAN / ok"];
+            s4 -> s4 [label="WATER / ok"];
+            s4 -> s3 [label="POD / ok"];
+            s4 -> s1 [label="BUTTON / error"];
+            s4 -> s0 [label="CLEAN / ok"];
+            s5 -> s1 [label="WATER / error"];
+            s5 -> s1 [label="POD / error"];
+            s5 -> s1 [label="BUTTON / error"];
+            s5 -> s0 [label="CLEAN / ok"];
+          }
+        DOT
+      end
     end
   end
 end

--- a/test/lernen/automaton/mealy_test.rb
+++ b/test/lernen/automaton/mealy_test.rb
@@ -85,7 +85,7 @@ module Lernen
 
       #: () -> void
       def test_from_and_to_automata_wiki_dot
-        # From https://automata.cs.ru.nl/Syntax/Moore.
+        # From https://automata.cs.ru.nl/Syntax/Mealy.
         mealy, state_to_name = Mealy.from_automata_wiki_dot(<<~DOT)
           digraph g {
             __start0 [label="" shape="none"];

--- a/test/lernen/automaton/moore_test.rb
+++ b/test/lernen/automaton/moore_test.rb
@@ -41,10 +41,10 @@ module Lernen
 
         expected = <<~MERMAID
           flowchart TD
-            0(("0 | 0"))
-            1(("1 | 1"))
-            2(("2 | 2"))
-            3(("3 | 3"))
+            0("0 | 0")
+            1("1 | 1")
+            2("2 | 2")
+            3("3 | 3")
 
             0 -- "#quot;0#quot;" --> 0
             0 -- "#quot;1#quot;" --> 1
@@ -65,10 +65,10 @@ module Lernen
 
         expected = <<~'DOT'
           digraph {
-            0 [label="0 | 0", shape=circle];
-            1 [label="1 | 1", shape=circle];
-            2 [label="2 | 2", shape=circle];
-            3 [label="3 | 3", shape=circle];
+            0 [label="{ 0 | 0 }", shape=record, style=rounded];
+            1 [label="{ 1 | 1 }", shape=record, style=rounded];
+            2 [label="{ 2 | 2 }", shape=record, style=rounded];
+            3 [label="{ 3 | 3 }", shape=record, style=rounded];
 
             0 -> 0 [label="\"0\""];
             0 -> 1 [label="\"1\""];
@@ -82,6 +82,82 @@ module Lernen
         DOT
         assert_equal expected, moore.to_dot
         assert_predicate moore.to_dot, :frozen?
+      end
+
+      #: () -> void
+      def test_from_and_to_automata_wiki_dot
+        # From https://automata.cs.ru.nl/Syntax/Moore.
+        moore, state_to_name = Moore.from_automata_wiki_dot(<<~DOT)
+          digraph g {
+            __start0 [label="" shape="none"];
+            __start0 -> A;
+
+    	      A [shape="record", style="rounded", label="{ A | 0 }"];
+    	      B [shape="record", style="rounded", label="{ B | 0 }"];
+    	      C [shape="record", style="rounded", label="{ C | 0 }"];
+    	      D [shape="record", style="rounded", label="{ D | 0 }"];
+    	      E [shape="record", style="rounded", label="{ E | 0 }"];
+    	      F [shape="record", style="rounded", label="{ F | 0 }"];
+    	      G [shape="record", style="rounded", label="{ G | 0 }"];
+    	      H [shape="record", style="rounded", label="{ H | 0 }"];
+    	      I [shape="record", style="rounded", label="{ I | 1 }"];
+
+            A -> D [label="0"];
+            A -> B [label="1"];
+            B -> E [label="0"];
+            B -> C [label="1"];
+            C -> F [label="0"];
+            C -> C [label="1"];
+            D -> G [label="0"];
+            D -> E [label="1"];
+            E -> H [label="0"];
+            E -> F [label="1"];
+            F -> I [label="0"];
+            F -> F [label="1"];
+            G -> G [label="0"];
+            G -> H [label="1"];
+            H -> H [label="0"];
+            H -> I [label="1"];
+            I -> I [label="0"];
+            I -> I [label="1"];
+          }
+        DOT
+        source = moore.to_automata_wiki_dot(state_to_name)
+
+        assert_equal <<~DOT, source
+          digraph {
+            __start0 [label="", shape=none];
+            A [label="{ A | 0 }", shape=record, style=rounded];
+            B [label="{ B | 0 }", shape=record, style=rounded];
+            C [label="{ C | 0 }", shape=record, style=rounded];
+            D [label="{ D | 0 }", shape=record, style=rounded];
+            E [label="{ E | 0 }", shape=record, style=rounded];
+            F [label="{ F | 0 }", shape=record, style=rounded];
+            G [label="{ G | 0 }", shape=record, style=rounded];
+            H [label="{ H | 0 }", shape=record, style=rounded];
+            I [label="{ I | 1 }", shape=record, style=rounded];
+
+            __start0 -> A;
+            A -> D [label="0"];
+            A -> B [label="1"];
+            B -> E [label="0"];
+            B -> C [label="1"];
+            C -> F [label="0"];
+            C -> C [label="1"];
+            D -> G [label="0"];
+            D -> E [label="1"];
+            E -> H [label="0"];
+            E -> F [label="1"];
+            F -> I [label="0"];
+            F -> F [label="1"];
+            G -> G [label="0"];
+            G -> H [label="1"];
+            H -> H [label="0"];
+            H -> I [label="1"];
+            I -> I [label="0"];
+            I -> I [label="1"];
+          }
+        DOT
       end
     end
   end

--- a/test/lernen/automaton/spa_test.rb
+++ b/test/lernen/automaton/spa_test.rb
@@ -178,6 +178,101 @@ module Lernen
         assert_equal expected, spa.to_dot
         assert_predicate spa.to_dot, :frozen?
       end
+
+      #: () -> void
+      def test_from_and_to_automata_wiki_dot
+        spa, proc_to_state_to_name = SPA.from_automata_wiki_dot(<<~DOT)
+          digraph g {
+            __start0 [label="", shape=none];
+            __start0 -> __start0_F [lhead="cluster_g0"];
+            __return [label="↵"];
+
+            subgraph cluster_g0 {
+              label="F";
+
+              __start0_F [label="", shape=none];
+              __start0_F -> g0_0;
+
+              g0_0 [label="0", shape=doublecircle];
+              g0_1 [label="1", shape=doublecircle];
+              g0_2 [label="2", shape=circle];
+              g0_3 [label="3", shape=doublecircle];
+              g0_4 [label="4", shape=circle];
+              g0_5 [label="5", shape=doublecircle];
+
+              g0_0 -> g0_1 [label="a"];
+              g0_0 -> g0_3 [label="b"];
+              g0_0 -> g0_5 [label="G"];
+              g0_1 -> g0_2 [label="F"];
+              g0_2 -> g0_5 [label="a"];
+              g0_3 -> g0_4 [label="F"];
+              g0_4 -> g0_5 [label="b"];
+            }
+
+            subgraph cluster_g1 {
+              label="G";
+
+              __start0_G [label="", shape=none];
+              __start0_G -> g1_0;
+
+              g1_0 [label="0", shape=circle];
+              g1_1 [label="1", shape=doublecircle];
+              g1_2 [label="2", shape=circle];
+              g1_3 [label="3", shape=doublecircle];
+
+              g1_0 -> g1_1 [label="c"];
+              g1_0 -> g1_3 [label="F"];
+              g1_1 -> g1_2 [label="G"];
+              g1_2 -> g1_3 [label="c"];
+            }
+          }
+        DOT
+        source = spa.to_automata_wiki_dot(proc_to_state_to_name)
+
+        assert_equal <<~DOT, source
+          digraph {
+            __start0 [label="", shape=none];
+            __return [label="↵", shape=circle];
+
+            __start0 -> __start0_F;
+
+            subgraph cluster_g0 {
+              label="F";
+              __start0_F [label="", shape=none];
+              g0_0 [label="g0_0", shape=doublecircle];
+              g0_1 [label="g0_1", shape=doublecircle];
+              g0_2 [label="g0_2", shape=circle];
+              g0_3 [label="g0_3", shape=doublecircle];
+              g0_4 [label="g0_4", shape=circle];
+              g0_5 [label="g0_5", shape=doublecircle];
+
+              __start0_F -> g0_0;
+              g0_0 -> g0_1 [label="a"];
+              g0_0 -> g0_3 [label="b"];
+              g0_0 -> g0_5 [label="G"];
+              g0_1 -> g0_2 [label="F"];
+              g0_2 -> g0_5 [label="a"];
+              g0_3 -> g0_4 [label="F"];
+              g0_4 -> g0_5 [label="b"];
+            }
+
+            subgraph cluster_g1 {
+              label="G";
+              __start0_G [label="", shape=none];
+              g1_0 [label="g1_0", shape=circle];
+              g1_1 [label="g1_1", shape=doublecircle];
+              g1_2 [label="g1_2", shape=circle];
+              g1_3 [label="g1_3", shape=doublecircle];
+          
+              __start0_G -> g1_0;
+              g1_0 -> g1_1 [label="c"];
+              g1_0 -> g1_3 [label="F"];
+              g1_1 -> g1_2 [label="G"];
+              g1_2 -> g1_3 [label="c"];
+            }
+          }
+        DOT
+      end
     end
   end
 end

--- a/test/lernen/automaton/vpa_test.rb
+++ b/test/lernen/automaton/vpa_test.rb
@@ -70,11 +70,10 @@ module Lernen
 
       #: () -> void
       def test_from_and_to_automata_wiki_dot
-        # From https://automata.cs.ru.nl/Syntax/Moore.
         vpa, state_to_name = VPA.from_automata_wiki_dot(<<~DOT)
-            digraph g {
-              __start0 [label="" shape="none"]
-              __start0 -> s0
+          digraph g {
+            __start0 [label="" shape="none"]
+            __start0 -> s0
 
             s0 [shape="circle" label="s0"]
             s1 [shape="doublecircle" label="s1"]

--- a/test/lernen/automaton/vpa_test.rb
+++ b/test/lernen/automaton/vpa_test.rb
@@ -67,6 +67,48 @@ module Lernen
         assert_equal expected, vpa.to_dot
         assert_predicate vpa.to_dot, :frozen?
       end
+
+      #: () -> void
+      def test_from_and_to_automata_wiki_dot
+        # From https://automata.cs.ru.nl/Syntax/Moore.
+        vpa, state_to_name = VPA.from_automata_wiki_dot(<<~DOT)
+            digraph g {
+              __start0 [label="" shape="none"]
+              __start0 -> s0
+
+            s0 [shape="circle" label="s0"]
+            s1 [shape="doublecircle" label="s1"]
+
+            s0 -> s0 [label="0"]
+            s0 -> s1 [label="1"]
+            s1 -> s1 [label="0"]
+            s1 -> s1 [label="1"]
+            s0 -> s0 [label=") / (s0, ()"]
+            s0 -> s1 [label=") / (s1, ()"]
+            s1 -> s1 [label=") / (s0, ()"]
+            s1 -> s1 [label=") / (s1, ()"]
+          }
+        DOT
+        source = vpa.to_automata_wiki_dot(state_to_name)
+
+        assert_equal <<~DOT, source
+          digraph {
+            __start0 [label="", shape=none];
+            s0 [label="s0", shape=circle];
+            s1 [label="s1", shape=doublecircle];
+
+            __start0 -> s0;
+            s0 -> s0 [label="0"];
+            s0 -> s1 [label="1"];
+            s1 -> s1 [label="0"];
+            s1 -> s1 [label="1"];
+            s0 -> s0 [label=") / (s0, ()"];
+            s0 -> s1 [label=") / (s1, ()"];
+            s1 -> s1 [label=") / (s0, ()"];
+            s1 -> s1 [label=") / (s1, ()"];
+          }
+        DOT
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds:

- `DFA.from_automata_wiki_dot`, `DFA#to_automata_wiki_dot`
- `Moore.from_automata_wiki_dot`, `Moore#to_automata_wiki_dot`
- `Mealy.from_automata_wiki_dot`, `Mealy#to_automata_wiki_dot`
- `VPA.from_automata_wiki_dot`, `VPA#to_automata_wiki_dot`
- `SPA.from_automata_wiki_dot`, `SPA#to_automata_wiki_dot`

Now, we can use [Automata Wiki](https://automata.cs.ru.nl)'s DOT format as serialization for automata.