### PR TITLE
Add `repeats_cex_evaluation` param

### DIFF
--- a/lib/lernen/algorithm/kearns_vazirani.rb
+++ b/lib/lernen/algorithm/kearns_vazirani.rb
@@ -16,17 +16,17 @@ module Lernen
       #: [In] (
       #    Array[In] alphabet, System::SUL[In, bool] sul, Equiv::Oracle[In, bool] oracle,
       #    automaton_type: :dfa,
-      #    ?cex_processing: cex_processing_method, ?max_learning_rounds: Integer | nil
+      #    ?cex_processing: cex_processing_method, ?repeats_cex_evaluation: bool, ?max_learning_rounds: Integer | nil
       #  ) -> Automaton::DFA[In]
       #: [In, Out] (
       #    Array[In] alphabet, System::SUL[In, Out] sul, Equiv::Oracle[In, Out] oracle,
       #    automaton_type: :mealy,
-      #    ?cex_processing: cex_processing_method, ?max_learning_rounds: Integer | nil
+      #    ?cex_processing: cex_processing_method, ?repeats_cex_evaluation: bool, ?max_learning_rounds: Integer | nil
       #  ) -> Automaton::Mealy[In, Out]
       #: [In, Out] (
       #    Array[In] alphabet, System::SUL[In, Out] sul, Equiv::Oracle[In, Out] oracle,
       #    automaton_type: :moore,
-      #    ?cex_processing: cex_processing_method, ?max_learning_rounds: Integer | nil
+      #    ?cex_processing: cex_processing_method, ?repeats_cex_evaluation: bool, ?max_learning_rounds: Integer | nil
       #  ) -> Automaton::Moore[In, Out]
       def self.learn( # steep:ignore
         alphabet,
@@ -34,10 +34,11 @@ module Lernen
         oracle,
         automaton_type:,
         cex_processing: :binary,
+        repeats_cex_evaluation: true,
         max_learning_rounds: nil
       )
         learner = KearnsVaziraniLearner.new(alphabet, sul, automaton_type:, cex_processing:)
-        learner.learn(oracle, max_learning_rounds:)
+        learner.learn(oracle, repeats_cex_evaluation:, max_learning_rounds:)
       end
     end
   end

--- a/lib/lernen/algorithm/kearns_vazirani_vpa.rb
+++ b/lib/lernen/algorithm/kearns_vazirani_vpa.rb
@@ -16,7 +16,7 @@ module Lernen
       #: [In, Call, Return] (
       #    Array[In] alphabet, Array[Call] call_alphabet, Array[Return] return_alphabet,
       #    System::MooreLikeSUL[In | Call | Return, bool] sul, Equiv::Oracle[In | Call | Return, bool] oracle,
-      #    ?cex_processing: cex_processing_method, ?max_learning_rounds: Integer | nil
+      #    ?cex_processing: cex_processing_method, ?repeats_cex_evaluation: bool, ?max_learning_rounds: Integer | nil
       #  ) -> Automaton::VPA[In, Call, Return]
       def self.learn( # steep:ignore
         alphabet,
@@ -25,10 +25,11 @@ module Lernen
         sul,
         oracle,
         cex_processing: :binary,
+        repeats_cex_evaluation: true,
         max_learning_rounds: nil
       )
         learner = KearnsVaziraniVPALearner.new(alphabet, call_alphabet, return_alphabet, sul, cex_processing:)
-        learner.learn(oracle, max_learning_rounds:)
+        learner.learn(oracle, repeats_cex_evaluation:, max_learning_rounds:)
       end
     end
   end

--- a/lib/lernen/algorithm/lsharp.rb
+++ b/lib/lernen/algorithm/lsharp.rb
@@ -18,6 +18,7 @@ module Lernen
       #    System::SUL[In, bool] sul,
       #    Equiv::Oracle[In, bool] oracle,
       #    automaton_type: :dfa,
+      #    ?repeats_cex_evaluation: bool,
       #    ?max_learning_rounds: Integer | nil
       #  ) -> Automaton::DFA[In]
       #: [In, Out] (
@@ -25,6 +26,7 @@ module Lernen
       #    System::SUL[In, Out] sul,
       #    Equiv::Oracle[In, Out] oracle,
       #    automaton_type: :mealy,
+      #    ?repeats_cex_evaluation: bool,
       #    ?max_learning_rounds: Integer | nil
       #  ) -> Automaton::Mealy[In, Out]
       #: [In, Out] (
@@ -32,11 +34,19 @@ module Lernen
       #    System::SUL[In, Out] sul,
       #    Equiv::Oracle[In, Out] oracle,
       #    automaton_type: :moore,
+      #    ?repeats_cex_evaluation: bool,
       #    ?max_learning_rounds: Integer | nil
       #  ) -> Automaton::Moore[In, Out]
-      def self.learn(alphabet, sul, oracle, automaton_type:, max_learning_rounds: nil) # steep:ignore
+      def self.learn( # steep:ignore
+        alphabet,
+        sul,
+        oracle,
+        automaton_type:,
+        repeats_cex_evaluation: true,
+        max_learning_rounds: nil
+      )
         learner = LSharpLearner.new(alphabet, sul, automaton_type:)
-        learner.learn(oracle, max_learning_rounds:)
+        learner.learn(oracle, repeats_cex_evaluation:, max_learning_rounds:)
       end
     end
   end

--- a/lib/lernen/algorithm/lstar.rb
+++ b/lib/lernen/algorithm/lstar.rb
@@ -21,17 +21,20 @@ module Lernen
       #: [In] (
       #    Array[In] alphabet, System::SUL[In, bool] sul, Equiv::Oracle[In, bool] oracle,
       #    automaton_type: :dfa,
-      #    ?cex_processing: cex_processing_method | nil, ?max_learning_rounds: Integer | nil
+      #    ?cex_processing: cex_processing_method | nil, ?repeats_cex_evaluation: bool,
+      #    ?max_learning_rounds: Integer | nil
       #  ) -> Automaton::DFA[In]
       #: [In, Out] (
       #    Array[In] alphabet, System::SUL[In, Out] sul, Equiv::Oracle[In, Out] oracle,
       #    automaton_type: :mealy,
-      #    ?cex_processing: cex_processing_method | nil, ?max_learning_rounds: Integer | nil
+      #    ?cex_processing: cex_processing_method | nil, ?repeats_cex_evaluation: bool,
+      #    ?max_learning_rounds: Integer | nil
       #  ) -> Automaton::Mealy[In, Out]
       #: [In, Out] (
       #    Array[In] alphabet, System::SUL[In, Out] sul, Equiv::Oracle[In, Out] oracle,
       #    automaton_type: :moore,
-      #    ?cex_processing: cex_processing_method | nil, ?max_learning_rounds: Integer | nil
+      #    ?cex_processing: cex_processing_method | nil, ?repeats_cex_evaluation: bool,
+      #    ?max_learning_rounds: Integer | nil
       #  ) -> Automaton::Moore[In, Out]
       def self.learn( # steep:ignore
         alphabet,
@@ -39,10 +42,11 @@ module Lernen
         oracle,
         automaton_type:,
         cex_processing: :binary,
+        repeats_cex_evaluation: true,
         max_learning_rounds: nil
       )
         learner = LStarLearner.new(alphabet, sul, automaton_type:, cex_processing:)
-        learner.learn(oracle, max_learning_rounds:)
+        learner.learn(oracle, repeats_cex_evaluation:, max_learning_rounds:)
       end
     end
   end

--- a/lib/lernen/algorithm/procedural.rb
+++ b/lib/lernen/algorithm/procedural.rb
@@ -25,6 +25,7 @@ module Lernen
       #    ?algorithm_params: Hash[Symbol, untyped],
       #    ?cex_processing: cex_processing_method,
       #    ?scan_procs: bool,
+      #    ?repeats_cex_evaluation: bool
       #    ?max_learning_rounds: Integer | nil
       #  ) -> Automaton::SPA[In, Call, Return]
       def self.learn( # steep:ignore
@@ -37,6 +38,7 @@ module Lernen
         algorithm_params: {},
         cex_processing: :binary,
         scan_procs: true,
+        repeats_cex_evaluation: true,
         max_learning_rounds: nil
       )
         learner =
@@ -50,7 +52,7 @@ module Lernen
             cex_processing:,
             scan_procs:
           )
-        learner.learn(oracle, max_learning_rounds:)
+        learner.learn(oracle, repeats_cex_evaluation:, max_learning_rounds:)
       end
     end
   end

--- a/sig/generated/lernen/algorithm/kearns_vazirani.rbs
+++ b/sig/generated/lernen/algorithm/kearns_vazirani.rbs
@@ -12,21 +12,21 @@ module Lernen
       # : [In] (
       #    Array[In] alphabet, System::SUL[In, bool] sul, Equiv::Oracle[In, bool] oracle,
       #    automaton_type: :dfa,
-      #    ?cex_processing: cex_processing_method, ?max_learning_rounds: Integer | nil
+      #    ?cex_processing: cex_processing_method, ?repeats_cex_evaluation: bool, ?max_learning_rounds: Integer | nil
       #  ) -> Automaton::DFA[In]
       # : [In, Out] (
       #    Array[In] alphabet, System::SUL[In, Out] sul, Equiv::Oracle[In, Out] oracle,
       #    automaton_type: :mealy,
-      #    ?cex_processing: cex_processing_method, ?max_learning_rounds: Integer | nil
+      #    ?cex_processing: cex_processing_method, ?repeats_cex_evaluation: bool, ?max_learning_rounds: Integer | nil
       #  ) -> Automaton::Mealy[In, Out]
       # : [In, Out] (
       #    Array[In] alphabet, System::SUL[In, Out] sul, Equiv::Oracle[In, Out] oracle,
       #    automaton_type: :moore,
-      #    ?cex_processing: cex_processing_method, ?max_learning_rounds: Integer | nil
+      #    ?cex_processing: cex_processing_method, ?repeats_cex_evaluation: bool, ?max_learning_rounds: Integer | nil
       #  ) -> Automaton::Moore[In, Out]
-      def self.learn: [In] (Array[In] alphabet, System::SUL[In, bool] sul, Equiv::Oracle[In, bool] oracle, automaton_type: :dfa, ?cex_processing: cex_processing_method, ?max_learning_rounds: Integer | nil) -> Automaton::DFA[In]
-                    | [In, Out] (Array[In] alphabet, System::SUL[In, Out] sul, Equiv::Oracle[In, Out] oracle, automaton_type: :mealy, ?cex_processing: cex_processing_method, ?max_learning_rounds: Integer | nil) -> Automaton::Mealy[In, Out]
-                    | [In, Out] (Array[In] alphabet, System::SUL[In, Out] sul, Equiv::Oracle[In, Out] oracle, automaton_type: :moore, ?cex_processing: cex_processing_method, ?max_learning_rounds: Integer | nil) -> Automaton::Moore[In, Out]
+      def self.learn: [In] (Array[In] alphabet, System::SUL[In, bool] sul, Equiv::Oracle[In, bool] oracle, automaton_type: :dfa, ?cex_processing: cex_processing_method, ?repeats_cex_evaluation: bool, ?max_learning_rounds: Integer | nil) -> Automaton::DFA[In]
+                    | [In, Out] (Array[In] alphabet, System::SUL[In, Out] sul, Equiv::Oracle[In, Out] oracle, automaton_type: :mealy, ?cex_processing: cex_processing_method, ?repeats_cex_evaluation: bool, ?max_learning_rounds: Integer | nil) -> Automaton::Mealy[In, Out]
+                    | [In, Out] (Array[In] alphabet, System::SUL[In, Out] sul, Equiv::Oracle[In, Out] oracle, automaton_type: :moore, ?cex_processing: cex_processing_method, ?repeats_cex_evaluation: bool, ?max_learning_rounds: Integer | nil) -> Automaton::Moore[In, Out]
     end
   end
 end

--- a/sig/generated/lernen/algorithm/kearns_vazirani_vpa.rbs
+++ b/sig/generated/lernen/algorithm/kearns_vazirani_vpa.rbs
@@ -12,9 +12,9 @@ module Lernen
       # : [In, Call, Return] (
       #    Array[In] alphabet, Array[Call] call_alphabet, Array[Return] return_alphabet,
       #    System::MooreLikeSUL[In | Call | Return, bool] sul, Equiv::Oracle[In | Call | Return, bool] oracle,
-      #    ?cex_processing: cex_processing_method, ?max_learning_rounds: Integer | nil
+      #    ?cex_processing: cex_processing_method, ?repeats_cex_evaluation: bool, ?max_learning_rounds: Integer | nil
       #  ) -> Automaton::VPA[In, Call, Return]
-      def self.learn: [In, Call, Return] (Array[In] alphabet, Array[Call] call_alphabet, Array[Return] return_alphabet, System::MooreLikeSUL[In | Call | Return, bool] sul, Equiv::Oracle[In | Call | Return, bool] oracle, ?cex_processing: cex_processing_method, ?max_learning_rounds: Integer | nil) -> Automaton::VPA[In, Call, Return]
+      def self.learn: [In, Call, Return] (Array[In] alphabet, Array[Call] call_alphabet, Array[Return] return_alphabet, System::MooreLikeSUL[In | Call | Return, bool] sul, Equiv::Oracle[In | Call | Return, bool] oracle, ?cex_processing: cex_processing_method, ?repeats_cex_evaluation: bool, ?max_learning_rounds: Integer | nil) -> Automaton::VPA[In, Call, Return]
     end
   end
 end

--- a/sig/generated/lernen/algorithm/learner.rbs
+++ b/sig/generated/lernen/algorithm/learner.rbs
@@ -15,15 +15,18 @@ module Lernen
     class Learner[In, Out]
       # Runs the learning algorithm and returns an inferred automaton.
       #
-      # `max_learning_rounds` is a parameter for specifying the maximum number of iterations for learning.
-      # When `max_learning_rounds: nil` is specified, it means the algorithm only stops if the equivalent
-      # hypothesis is found.
+      # - `repeats_cex_evaluation` is a parameter that determines whether the refinement of the hypothesis
+      #   is repeated until the counterexample returned by the oracle is no longer a counterexample.
+      # - `max_learning_rounds` is a parameter for specifying the maximum number of iterations for learning.
+      #   When `max_learning_rounds: nil` is specified, it means the algorithm only stops if the equivalent
+      #   hypothesis is found.
       #
       # : (
       #    Equiv::Oracle[In, Out] oracle,
+      #    ?repeats_cex_evaluation: bool,
       #    ?max_learning_rounds: Integer | nil
       #  ) -> Automaton::TransitionSystem[untyped, In, Out]
-      def learn: (Equiv::Oracle[In, Out] oracle, ?max_learning_rounds: Integer | nil) -> Automaton::TransitionSystem[untyped, In, Out]
+      def learn: (Equiv::Oracle[In, Out] oracle, ?repeats_cex_evaluation: bool, ?max_learning_rounds: Integer | nil) -> Automaton::TransitionSystem[untyped, In, Out]
 
       # Adds the given `input` to the alphabet.
       #

--- a/sig/generated/lernen/algorithm/lsharp.rbs
+++ b/sig/generated/lernen/algorithm/lsharp.rbs
@@ -14,6 +14,7 @@ module Lernen
       #    System::SUL[In, bool] sul,
       #    Equiv::Oracle[In, bool] oracle,
       #    automaton_type: :dfa,
+      #    ?repeats_cex_evaluation: bool,
       #    ?max_learning_rounds: Integer | nil
       #  ) -> Automaton::DFA[In]
       # : [In, Out] (
@@ -21,6 +22,7 @@ module Lernen
       #    System::SUL[In, Out] sul,
       #    Equiv::Oracle[In, Out] oracle,
       #    automaton_type: :mealy,
+      #    ?repeats_cex_evaluation: bool,
       #    ?max_learning_rounds: Integer | nil
       #  ) -> Automaton::Mealy[In, Out]
       # : [In, Out] (
@@ -28,11 +30,12 @@ module Lernen
       #    System::SUL[In, Out] sul,
       #    Equiv::Oracle[In, Out] oracle,
       #    automaton_type: :moore,
+      #    ?repeats_cex_evaluation: bool,
       #    ?max_learning_rounds: Integer | nil
       #  ) -> Automaton::Moore[In, Out]
-      def self.learn: [In] (Array[In] alphabet, System::SUL[In, bool] sul, Equiv::Oracle[In, bool] oracle, automaton_type: :dfa, ?max_learning_rounds: Integer | nil) -> Automaton::DFA[In]
-                    | [In, Out] (Array[In] alphabet, System::SUL[In, Out] sul, Equiv::Oracle[In, Out] oracle, automaton_type: :mealy, ?max_learning_rounds: Integer | nil) -> Automaton::Mealy[In, Out]
-                    | [In, Out] (Array[In] alphabet, System::SUL[In, Out] sul, Equiv::Oracle[In, Out] oracle, automaton_type: :moore, ?max_learning_rounds: Integer | nil) -> Automaton::Moore[In, Out]
+      def self.learn: [In] (Array[In] alphabet, System::SUL[In, bool] sul, Equiv::Oracle[In, bool] oracle, automaton_type: :dfa, ?repeats_cex_evaluation: bool, ?max_learning_rounds: Integer | nil) -> Automaton::DFA[In]
+                    | [In, Out] (Array[In] alphabet, System::SUL[In, Out] sul, Equiv::Oracle[In, Out] oracle, automaton_type: :mealy, ?repeats_cex_evaluation: bool, ?max_learning_rounds: Integer | nil) -> Automaton::Mealy[In, Out]
+                    | [In, Out] (Array[In] alphabet, System::SUL[In, Out] sul, Equiv::Oracle[In, Out] oracle, automaton_type: :moore, ?repeats_cex_evaluation: bool, ?max_learning_rounds: Integer | nil) -> Automaton::Moore[In, Out]
     end
   end
 end

--- a/sig/generated/lernen/algorithm/lstar.rbs
+++ b/sig/generated/lernen/algorithm/lstar.rbs
@@ -17,21 +17,24 @@ module Lernen
       # : [In] (
       #    Array[In] alphabet, System::SUL[In, bool] sul, Equiv::Oracle[In, bool] oracle,
       #    automaton_type: :dfa,
-      #    ?cex_processing: cex_processing_method | nil, ?max_learning_rounds: Integer | nil
+      #    ?cex_processing: cex_processing_method | nil, ?repeats_cex_evaluation: bool,
+      #    ?max_learning_rounds: Integer | nil
       #  ) -> Automaton::DFA[In]
       # : [In, Out] (
       #    Array[In] alphabet, System::SUL[In, Out] sul, Equiv::Oracle[In, Out] oracle,
       #    automaton_type: :mealy,
-      #    ?cex_processing: cex_processing_method | nil, ?max_learning_rounds: Integer | nil
+      #    ?cex_processing: cex_processing_method | nil, ?repeats_cex_evaluation: bool,
+      #    ?max_learning_rounds: Integer | nil
       #  ) -> Automaton::Mealy[In, Out]
       # : [In, Out] (
       #    Array[In] alphabet, System::SUL[In, Out] sul, Equiv::Oracle[In, Out] oracle,
       #    automaton_type: :moore,
-      #    ?cex_processing: cex_processing_method | nil, ?max_learning_rounds: Integer | nil
+      #    ?cex_processing: cex_processing_method | nil, ?repeats_cex_evaluation: bool,
+      #    ?max_learning_rounds: Integer | nil
       #  ) -> Automaton::Moore[In, Out]
-      def self.learn: [In] (Array[In] alphabet, System::SUL[In, bool] sul, Equiv::Oracle[In, bool] oracle, automaton_type: :dfa, ?cex_processing: cex_processing_method | nil, ?max_learning_rounds: Integer | nil) -> Automaton::DFA[In]
-                    | [In, Out] (Array[In] alphabet, System::SUL[In, Out] sul, Equiv::Oracle[In, Out] oracle, automaton_type: :mealy, ?cex_processing: cex_processing_method | nil, ?max_learning_rounds: Integer | nil) -> Automaton::Mealy[In, Out]
-                    | [In, Out] (Array[In] alphabet, System::SUL[In, Out] sul, Equiv::Oracle[In, Out] oracle, automaton_type: :moore, ?cex_processing: cex_processing_method | nil, ?max_learning_rounds: Integer | nil) -> Automaton::Moore[In, Out]
+      def self.learn: [In] (Array[In] alphabet, System::SUL[In, bool] sul, Equiv::Oracle[In, bool] oracle, automaton_type: :dfa, ?cex_processing: cex_processing_method | nil, ?repeats_cex_evaluation: bool, ?max_learning_rounds: Integer | nil) -> Automaton::DFA[In]
+                    | [In, Out] (Array[In] alphabet, System::SUL[In, Out] sul, Equiv::Oracle[In, Out] oracle, automaton_type: :mealy, ?cex_processing: cex_processing_method | nil, ?repeats_cex_evaluation: bool, ?max_learning_rounds: Integer | nil) -> Automaton::Mealy[In, Out]
+                    | [In, Out] (Array[In] alphabet, System::SUL[In, Out] sul, Equiv::Oracle[In, Out] oracle, automaton_type: :moore, ?cex_processing: cex_processing_method | nil, ?repeats_cex_evaluation: bool, ?max_learning_rounds: Integer | nil) -> Automaton::Moore[In, Out]
     end
   end
 end

--- a/sig/generated/lernen/algorithm/procedural.rbs
+++ b/sig/generated/lernen/algorithm/procedural.rbs
@@ -19,9 +19,10 @@ module Lernen
       #    ?algorithm_params: Hash[Symbol, untyped],
       #    ?cex_processing: cex_processing_method,
       #    ?scan_procs: bool,
+      #    ?repeats_cex_evaluation: bool
       #    ?max_learning_rounds: Integer | nil
       #  ) -> Automaton::SPA[In, Call, Return]
-      def self.learn: [In, Call, Return] (Array[In] alphabet, Array[Call] call_alphabet, Return return_input, System::SUL[In | Call | Return, bool] sul, Equiv::Oracle[In | Call | Return, bool] oracle, ?algorithm: :lstar | :kearns_vazirani | :lsharp, ?algorithm_params: Hash[Symbol, untyped], ?cex_processing: cex_processing_method, ?scan_procs: bool, ?max_learning_rounds: Integer | nil) -> Automaton::SPA[In, Call, Return]
+      def self.learn: (untyped alphabet, untyped call_alphabet, untyped return_input, untyped sul, untyped oracle, ?algorithm: untyped, ?algorithm_params: untyped, ?cex_processing: untyped, ?scan_procs: untyped, ?repeats_cex_evaluation: untyped, ?max_learning_rounds: untyped) -> untyped
     end
   end
 end


### PR DESCRIPTION
This PR adds the `repeats_cex_evaluation` param to each learning algorithm.

This is a parameter that determines whether the refinement of the hypothesis is repeated until the counterexample returned by the oracle is no longer a counterexample.